### PR TITLE
Fix Link and Typo at `Don't Repeat Yourself` Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Sooner or later I will complete it with the relative answers. Feel free to contr
   * [Anti-Corruption Layer](#anti-corruption-layer)
   * [Singleton](#singleton)
   * [Data Abstraction](#data-abstraction)
-  * [Don't Repeat Yourself](#don-t-repeat-yourself)
+  * [Don't Repeat Yourself](#dont-repeat-yourself)
   * [Dependency Hell](#depencendy-hell)
   * [Goto Is Evil](#goto-is-evil)
   * [Robustness Principle](#robustness-principle)

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ Singleton is a design pattern that restricts the instantiation of a class to one
 The ability to change implementation without affecting clients is called Data Abstraction. Produce an example violating this property, then fix it.<br/>
 [Resources](design-patterns/data-abstraction.md)
 
-#### Dont't Repeat Yourself
+#### Don't Repeat Yourself
 Write a snippet of code violating the Don't Repeat Yourself (DRY) principle. Then, fix it.<br/>
 [Resources](design-patterns/dont-repeat-yourself.md)
 


### PR DESCRIPTION
This maybe a small fix, but I find it useful it people can directly jump to `Don't Repeat Yourself` section.