### PR TITLE
fix: Data Abstraction fixed example

### DIFF
--- a/design-patterns/data-abstraction.md
+++ b/design-patterns/data-abstraction.md
@@ -17,13 +17,13 @@ const titlePage = myBook.pages[0];
 Fixed:
 ```javascript
 class Book {
-    constructor(title, pages) {
-        this.title = title;
+    constructor(pages, title) {
         this.pages = pages;
+        this.title = title;
     }
 
     getTitlePage() {
-        return this.pages[0];
+        return this.title || this.pages[0];
     }   
 }
 


### PR DESCRIPTION
Bugfix: Change params order
Otherwise will error with: `Uncaught TypeError: Cannot read property '0' of undefined`

Optional: Add `this.title` to `getTitlePage` return, not necessary but adds a purpose to `title` property

